### PR TITLE
added BioPortal to publishing platforms

### DIFF
--- a/semantic-tools.md
+++ b/semantic-tools.md
@@ -50,6 +50,7 @@
 - [pyLODE](https://github.com/RDFLib/pyLODE)
 - [ELDA](https://github.com/epimorphics/elda)
 - [pyLDAPI](https://github.com/RDFLib/pyLDAPI)
+- [BioPortal](https://bioportal.bioontology.org) - research submissions in any domain
 
 ## Full service SKOS/RDF platforms
 - [TopBraid EDG](https://www.topquadrant.com/products/topbraid-enterprise-data-governance/)


### PR DESCRIPTION
In case you find it appropriate, adding BioPortal as a general-purpose platform for science ontologies/vocabularies